### PR TITLE
2 instruments: Offset select and move

### DIFF
--- a/Controllers/DrawController.cs
+++ b/Controllers/DrawController.cs
@@ -38,79 +38,24 @@ namespace AdaptiveSpritesDMItool.Controllers
         public static Point pointOffset;
 
         /// <summary>
-        /// the mouse clicked on it while moving.
+        /// location of mouse click in the selected area
         /// </summary>
         public static Point pointOffsetDown;
+
+        /// <summary>
+        /// Coordinates of the smallest point of the offset boundaries
+        /// </summary>
         public static Point pointOffsetMin;
+
+        /// <summary>
+        /// Coordinates of the largest point of the offset boundaries
+        /// </summary>
         public static Point pointOffsetMax;
 
-        public static void UpdatePointOffsetBounds(Point point1, Point point2)
-        {
-            pointOffsetMin.X = Math.Min(point1.X, point2.X);
-            pointOffsetMin.Y = Math.Min(point1.Y, point2.Y);
-
-            pointOffsetMax.X = Math.Max(point1.X, point2.X);
-            pointOffsetMax.Y = Math.Max(point1.Y, point2.Y);
-
-            Debug.WriteLine($"Update Point Offset Bounds, min: {pointOffsetMin}, max: {pointOffsetMax}. pointOffset: {pointOffset}, Down: {pointOffsetDown}, Last: {pointOffsetLast}");
-        }
-
-
-        public static void UpdatePointOffset()
-        {
-            var cellsSize = EnvironmentController.dataImageState.imageCellsSize;
-            Point mousePos = MouseController.currentMousePosition;
-
-            pointOffset.X = mousePos.X - pointOffsetDown.X;
-            pointOffset.Y = mousePos.Y - pointOffsetDown.Y;
-
-            int XBeyondMin = pointOffset.X + pointOffsetMin.X;
-            int YBeyondMin = pointOffset.Y + pointOffsetMin.Y;
-            // Прибавляем остаток, тем самым выравнивая точку по и оффсет по краям и границам, чтобы не перейти их.
-            if (XBeyondMin < 0) 
-                pointOffset.X -= XBeyondMin;
-            if (YBeyondMin < 0) 
-                pointOffset.Y -= YBeyondMin;
-
-            //Debug.WriteLine($"pointOffset: {pointOffset}, XbeyondMin: {XBeyondMin}, YBeyondMin: {YBeyondMin}");
-
-            int xMax = cellsSize.Width - 1;
-            int yMax = cellsSize.Height - 1;
-            // расстояние от max до границы
-            int Xdist = xMax - pointOffsetMax.X;
-            int Ydist = yMax - pointOffsetMax.Y;
-            // максимум куда (коорд) можно сместить выбранный
-            int XdistMax = pointOffsetDown.X + Xdist;
-            int YdistMax = pointOffsetDown.Y + Ydist;
-            // допустимо смещать ВЫБРАННЫЙ на расстояние MAX до данной границы
-            if (mousePos.X > XdistMax) 
-                pointOffset.X = Xdist;
-            if (mousePos.Y > YdistMax) 
-                pointOffset.Y = Ydist;
-
-            //Debug.WriteLine($"Update Point Offset, where Down {pointOffsetDown}, offset: {pointOffset}, min: {pointOffsetMin}, max: {pointOffsetMax}, mousePos: {mousePos}");
-        }
-
-        public static void UpdatePointOffsetDown()
-        {
-            pointOffsetDown = MouseController.currentMousePosition;
-            pointOffsetDown.X -= pointOffset.X;
-            pointOffsetDown.Y -= pointOffset.Y;
-        }
-
-        public static void ResetOffset()
-        {
-            pointOffsetMin.X += pointOffset.X;
-            pointOffsetMin.Y += pointOffset.Y;
-
-            pointOffsetMax.X += pointOffset.X;
-            pointOffsetMax.Y += pointOffset.Y;
-
-            pointOffset = new Point(0, 0);
-            pointOffsetDown = new Point(0, 0);
-            pointOffsetLast = new Point(0, 0);
-        }
-
+        /// <summary>
+        /// The point showing what the previous offset was
+        /// </summary>
+        private static Point pointOffsetLast = new Point(0, 0);
 
 
         #region Draw
@@ -151,23 +96,11 @@ namespace AdaptiveSpritesDMItool.Controllers
         }
 
 
-
-
-
-
-
-
-
-
-
-
-
         #region Move Selected Area
 
-
-
-
-
+        /// <summary>
+        /// Updating data storage with saving new coordinates and references to values.
+        /// </summary>
         public static void SetStoragePoints()
         {
             if (pointsStorage.Count == 0) return;
@@ -198,14 +131,13 @@ namespace AdaptiveSpritesDMItool.Controllers
                     Point selectedPoint = new Point(tempPoint.X + pointOffset.X, tempPoint.Y + pointOffset.Y);
                     selectedPoint = CorrectMousePositionPoint(stateDirection, selectedPoint, cellsSize);
 
-                    //Point storagePoint = pointsStorage[stateDirection][point.Key];
                     Point storagePoint = pointsStorage[stateDirection][point.Key];
                     storagePoint = CorrectMousePositionPoint(stateDirection, storagePoint, cellsSize);
 
-                    Debug.WriteLine("======================================");
-                    Debug.WriteLine($"point: {point}, tempPoint: {tempPoint}");
-                    Debug.WriteLine($"selectedPoint: {selectedPoint}, storagePoint: {storagePoint}");
-                    Debug.WriteLine($"offset: {pointOffset}, down: {pointOffsetDown}, mouse: {MouseController.currentMousePosition}");
+                    //Debug.WriteLine("======================================");
+                    //Debug.WriteLine($"point: {point}, tempPoint: {tempPoint}");
+                    //Debug.WriteLine($"selectedPoint: {selectedPoint}, storagePoint: {storagePoint}");
+                    //Debug.WriteLine($"offset: {pointOffset}, down: {pointOffsetDown}, mouse: {MouseController.currentMousePosition}");
 
                     // Update Data Pixel Storage
                     UpdatePixel(stateDirection, bitmapEditable, selectedPoint, storagePoint);
@@ -215,25 +147,6 @@ namespace AdaptiveSpritesDMItool.Controllers
 
 
             pointsStorage = new Dictionary<StateDirection, Dictionary<Point, Point>>();
-        }
-
-
-
-
-
-
-
-
-
-
-        /// <summary>
-        /// Get an array of keys from pointStorage with pointOffset.
-        /// </summary>
-        public static Point[] GetStoragePoints(StateDirection stateDirection)
-        {
-            if(pointsStorage.Count == 0)
-                return new Point[0];
-            return pointsStorage[stateDirection].Keys.Select(point => new Point(point.X + pointOffset.X, point.Y + pointOffset.Y)).ToArray();
         }
 
         /// <summary>
@@ -261,13 +174,12 @@ namespace AdaptiveSpritesDMItool.Controllers
             }
         }
 
-
-        private static Point pointOffsetLast = new Point(0, 0);
-
+        /// <summary>
+        /// Visualization of selected points with each pixel.
+        /// </summary>
+        /// <param name="points"></param>
         public static void ViewSelectedPoints(Point[] points)
         {
-            //if (pickedPoint.X < 0 || pickedPoint.Y < 0) return;
-
             if (points.Length > 1 && pointOffset.X == 0 && pointOffset.Y == 0) return;
             if (pointOffsetLast.X == pointOffset.X && pointOffsetLast.Y == pointOffset.Y) return;
             pointOffsetLast = pointOffset;
@@ -275,8 +187,6 @@ namespace AdaptiveSpritesDMItool.Controllers
             var cellsSize = EnvironmentController.dataImageState.imageCellsSize;
             int pixelSize = EnvironmentController.dataImageState.pixelSize;
             var stateDirections = StatesController.GetStateDirections();
-
-            //pointColorStorage 
 
             foreach (var stateDirection in stateDirections)
             {
@@ -317,9 +227,6 @@ namespace AdaptiveSpritesDMItool.Controllers
 
                     //color = Colors.Red;
                     //color.A = 255;
-
-                    //tempPoint.X += stateDirection == StateDirection.North ? -5 : 5; // !!!!!!!!! TEST
-
                     bitmap.FillRectangle(
                         tempPoint.X * pixelSize + 1,
                         tempPoint.Y * pixelSize + 1,
@@ -330,12 +237,17 @@ namespace AdaptiveSpritesDMItool.Controllers
             }
         }
 
+        /// <summary>
+        /// Get an array of keys from pointStorage with pointOffset.
+        /// </summary>
+        public static Point[] GetStoragePoints(StateDirection stateDirection)
+        {
+            if (pointsStorage.Count == 0)
+                return new Point[0];
+            return pointsStorage[stateDirection].Keys.Select(point => new Point(point.X + pointOffset.X, point.Y + pointOffset.Y)).ToArray();
+        }
 
         #endregion Move Selected Area
-
-
-
-
 
 
         /// <summary>
@@ -433,7 +345,13 @@ namespace AdaptiveSpritesDMItool.Controllers
             EnvironmentController.dataPixelStorage.ChangePoint(stateDirection, (point.X, point.Y), (newPoint.X, newPoint.Y));
         }
 
-
+        /// <summary>
+        /// Change the point and update the Data Pixel Storage.
+        /// </summary>
+        /// <param name="stateDirection"></param>
+        /// <param name="bitmapEditable"></param>
+        /// <param name="pointKey"></param>
+        /// <param name="pointValue"></param>
         private static void UpdatePixel(StateDirection stateDirection, WriteableBitmap bitmapEditable, Point pointKey, Point pointValue)
         {
             Color color = GetPointColor(bitmapEditable, pointValue);
@@ -697,6 +615,93 @@ namespace AdaptiveSpritesDMItool.Controllers
             return newMousePoint;
 
         }
+
+
+
+        #region Offsets
+
+        /// <summary>
+        /// Update when the smallest and largest points within the selected area are found.
+        /// </summary>
+        /// <param name="point1"></param>
+        /// <param name="point2"></param>
+        public static void UpdatePointOffsetBounds(Point point1, Point point2)
+        {
+            pointOffsetMin.X = Math.Min(point1.X, point2.X);
+            pointOffsetMin.Y = Math.Min(point1.Y, point2.Y);
+
+            pointOffsetMax.X = Math.Max(point1.X, point2.X);
+            pointOffsetMax.Y = Math.Max(point1.Y, point2.Y);
+
+            Debug.WriteLine($"Update Point Offset Bounds, min: {pointOffsetMin}, max: {pointOffsetMax}. pointOffset: {pointOffset}, Down: {pointOffsetDown}, Last: {pointOffsetLast}");
+        }
+
+        /// <summary>
+        /// Finding the current offset and preventing it from going beyond the boundaries.
+        /// </summary>
+        public static void UpdatePointOffset()
+        {
+            var cellsSize = EnvironmentController.dataImageState.imageCellsSize;
+            Point mousePos = MouseController.currentMousePosition;
+
+            pointOffset.X = mousePos.X - pointOffsetDown.X;
+            pointOffset.Y = mousePos.Y - pointOffsetDown.Y;
+
+            int XBeyondMin = pointOffset.X + pointOffsetMin.X;
+            int YBeyondMin = pointOffset.Y + pointOffsetMin.Y;
+            // Прибавляем остаток, тем самым выравнивая точку по и оффсет по краям и границам, чтобы не перейти их.
+            if (XBeyondMin < 0)
+                pointOffset.X -= XBeyondMin;
+            if (YBeyondMin < 0)
+                pointOffset.Y -= YBeyondMin;
+
+            //Debug.WriteLine($"pointOffset: {pointOffset}, XbeyondMin: {XBeyondMin}, YBeyondMin: {YBeyondMin}");
+
+            int xMax = cellsSize.Width - 1;
+            int yMax = cellsSize.Height - 1;
+            // расстояние от max до границы
+            int Xdist = xMax - pointOffsetMax.X;
+            int Ydist = yMax - pointOffsetMax.Y;
+            // максимум куда (коорд) можно сместить выбранный
+            int XdistMax = pointOffsetDown.X + Xdist;
+            int YdistMax = pointOffsetDown.Y + Ydist;
+            // допустимо смещать ВЫБРАННЫЙ на расстояние MAX до данной границы
+            if (mousePos.X > XdistMax)
+                pointOffset.X = Xdist;
+            if (mousePos.Y > YdistMax)
+                pointOffset.Y = Ydist;
+
+            //Debug.WriteLine($"Update Point Offset, where Down {pointOffsetDown}, offset: {pointOffset}, min: {pointOffsetMin}, max: {pointOffsetMax}, mousePos: {mousePos}");
+        }
+
+        /// <summary>
+        /// Determining the location of the offsetDown when the offset itself and the mouse are shifted.
+        /// </summary>
+        public static void UpdatePointOffsetDown()
+        {
+            pointOffsetDown = MouseController.currentMousePosition;
+            pointOffsetDown.X -= pointOffset.X;
+            pointOffsetDown.Y -= pointOffset.Y;
+        }
+
+        /// <summary>
+        /// Reset all offsets.
+        /// </summary>
+        public static void ResetOffset()
+        {
+            pointOffsetMin.X += pointOffset.X;
+            pointOffsetMin.Y += pointOffset.Y;
+
+            pointOffsetMax.X += pointOffset.X;
+            pointOffsetMax.Y += pointOffset.Y;
+
+            pointOffset = new Point(0, 0);
+            pointOffsetDown = new Point(0, 0);
+            pointOffsetLast = new Point(0, 0);
+        }
+
+        #endregion Offsets
+
 
         #endregion Helpers
     }

--- a/Controllers/DrawController.cs
+++ b/Controllers/DrawController.cs
@@ -422,6 +422,8 @@ namespace AdaptiveSpritesDMItool.Controllers
         {
             bitmapEditable.SetPixel(point.X, point.Y, color);
             Point newPoint = pickedPointFromPreview;
+            if(StatesController.currentStateEditMode == StateEditType.Undo || StatesController.currentStateEditMode == StateEditType.UndoArea)
+                newPoint = point;
             //if (color == Colors.Transparent)
             if (isRemove)
             {

--- a/Controllers/DrawController.cs
+++ b/Controllers/DrawController.cs
@@ -11,15 +11,106 @@ using Point = System.Drawing.Point;
 using Color = System.Windows.Media.Color;
 using System.Diagnostics;
 using System.IO;
+using System.Numerics;
+using System.Collections;
+using System.Windows.Controls;
 
 namespace AdaptiveSpritesDMItool.Controllers
 {
     internal static class DrawController
     {
+        static int borderThickness = 2;
+
         /// <summary>
         /// Selected point for drawing on canvases.
         /// </summary>
-        public static Point pickedPoint = new Point(-1, -1);
+        public static Point pickedPointFromPreview = new Point(-1, -1);
+
+        /// <summary>
+        /// Storage of selected points for moving to a new area.
+        /// </summary>
+        static Dictionary<StateDirection, Dictionary<Point, Point>> pointsStorage = new Dictionary<StateDirection, Dictionary<Point, Point>>();
+
+        /// <summary>
+        /// Offset from the original selected coordinate area.
+        /// </summary>
+        public static Point pointOffset;
+
+        /// <summary>
+        /// the mouse clicked on it while moving.
+        /// </summary>
+        public static Point pointOffsetDown;
+        public static Point pointOffsetMin;
+        public static Point pointOffsetMax;
+
+        public static void UpdatePointOffsetBounds(Point point1, Point point2)
+        {
+            pointOffsetMin.X = Math.Min(point1.X, point2.X);
+            pointOffsetMin.Y = Math.Min(point1.Y, point2.Y);
+
+            pointOffsetMax.X = Math.Max(point1.X, point2.X);
+            pointOffsetMax.Y = Math.Max(point1.Y, point2.Y);
+
+            Debug.WriteLine($"Update Point Offset Bounds, min: {pointOffsetMin}, max: {pointOffsetMax}. pointOffset: {pointOffset}, Down: {pointOffsetDown}, Last: {pointOffsetLast}");
+        }
+
+
+        public static void UpdatePointOffset()
+        {
+            var cellsSize = EnvironmentController.dataImageState.imageCellsSize;
+            StateDirection stateDirection = StatesController.currentStateDirection;
+            Point mousePos = MouseController.currentMousePosition;
+
+            pointOffset.X = mousePos.X - pointOffsetDown.X;
+            pointOffset.Y = mousePos.Y - pointOffsetDown.Y;
+
+            int XBeyondMin = pointOffset.X + pointOffsetMin.X;
+            int YBeyondMin = pointOffset.Y + pointOffsetMin.Y;
+            // Прибавляем остаток, тем самым выравнивая точку по и оффсет по краям и границам, чтобы не перейти их.
+            if (XBeyondMin < 0) 
+                pointOffset.X -= XBeyondMin;
+            if (YBeyondMin < 0) 
+                pointOffset.Y -= YBeyondMin;
+
+            //Debug.WriteLine($"pointOffset: {pointOffset}, XbeyondMin: {XBeyondMin}, YBeyondMin: {YBeyondMin}");
+
+            int xMax = cellsSize.Width - 1;
+            int yMax = cellsSize.Height - 1;
+            // расстояние от max до границы
+            int Xdist = xMax - pointOffsetMax.X;
+            int Ydist = yMax - pointOffsetMax.Y;
+            // максимум куда (коорд) можно сместить выбранный
+            int XdistMax = pointOffsetDown.X + Xdist;
+            int YdistMax = pointOffsetDown.Y + Ydist;
+            // допустимо смещать ВЫБРАННЫЙ на расстояние MAX до данной границы
+            if (mousePos.X > XdistMax) 
+                pointOffset.X = Xdist;
+            if (mousePos.Y > YdistMax) 
+                pointOffset.Y = Ydist;
+
+            //Debug.WriteLine($"Update Point Offset, where Down {pointOffsetDown}, offset: {pointOffset}, min: {pointOffsetMin}, max: {pointOffsetMax}, mousePos: {mousePos}");
+        }
+
+        public static void UpdatePointOffsetDown()
+        {
+            pointOffsetDown = MouseController.currentMousePosition;
+            pointOffsetDown.X -= pointOffset.X;
+            pointOffsetDown.Y -= pointOffset.Y;
+        }
+
+        public static void ShiftOffset()
+        {
+            pointOffsetMin.X += pointOffset.X;
+            pointOffsetMin.Y += pointOffset.Y;
+
+            pointOffsetMax.X += pointOffset.X;
+            pointOffsetMax.Y += pointOffset.Y;
+
+            pointOffset = new Point(0, 0);
+            pointOffsetDown = new Point(0, 0);
+            pointOffsetLast = new Point(0, 0);
+        }
+
 
 
         #region Draw
@@ -28,13 +119,13 @@ namespace AdaptiveSpritesDMItool.Controllers
         /// Set selected points using picked point and update the Data Pixel Storage.
         /// </summary>
         /// <param name="points"></param>
-        public static void SetPickedPoints(Point[]? points = null)
+        public static void SetPickedPoint(Point[]? points = null)
         {
-            if (pickedPoint.X < 0 || pickedPoint.Y < 0) return;
+            if (pickedPointFromPreview.X < 0 || pickedPointFromPreview.Y < 0) return;
 
-            var bitmapSize = EnvironmentController.dataImageState.imageCellsSize;
+            var cellsSize = EnvironmentController.dataImageState.imageCellsSize;
             var stateDirections = StatesController.GetStateDirections();
-            Point mousePos = MouseController.GetCurrentMousePosition();
+            Point mousePos = MouseController.currentMousePosition;
             if (points == null) points = new Point[] { mousePos };
 
             foreach (var stateDirection in stateDirections)
@@ -50,14 +141,205 @@ namespace AdaptiveSpritesDMItool.Controllers
 
                 foreach (Point point in points)
                 {
-                    var tempPoint = CorrectMousePositionPoint(stateDirection, point, bitmapSize);
-                    UpdatePixel(stateDirection, bitmapEditable, tempPoint, color);
-                    UpdatePixel(stateDirection, bitmapOverlayEditable, tempPoint, colorOverlay);
+                    var tempPoint = CorrectMousePositionPoint(stateDirection, point, cellsSize);
+                    UpdatePixelPickedPoint(stateDirection, bitmapEditable, tempPoint, color);
+                    UpdatePixelPickedPoint(stateDirection, bitmapOverlayEditable, tempPoint, colorOverlay);
                 }
             }
 
             //pickedPoint = new Point(-1, -1);
         }
+
+
+
+
+
+
+
+
+
+
+
+
+
+        #region Move Selected Area
+
+
+
+
+
+
+        public static void SetPointsStorage()
+        {
+            //UpdatePickedPointsStorage(points);
+
+
+            var cellsSize = EnvironmentController.dataImageState.imageCellsSize;
+            var stateDirections = StatesController.GetStateDirections();
+
+
+            foreach (var stateDirection in stateDirections)
+            {
+                WriteableBitmap bitmapPreview = EnvironmentController.GetPreviewBMP(stateDirection, StateImageSideType.Left);
+                WriteableBitmap bitmapOverlayPreview = EnvironmentController.GetOverlayBMP(stateDirection, StateImageSideType.Left);
+
+                WriteableBitmap bitmapEditable = EnvironmentController.GetPreviewBMP(stateDirection, StateImageSideType.Right);
+                WriteableBitmap bitmapOverlayEditable = EnvironmentController.GetOverlayBMP(stateDirection, StateImageSideType.Right);
+
+                Point[] points = GetStoragePoints(stateDirection);
+                foreach (var point in pointsStorage[stateDirection])
+                {
+                    var tempPoint = CorrectMousePositionPoint(stateDirection, point.Key, cellsSize);
+                    var storagePoint = point.Value;
+                    UpdatePixel(stateDirection, bitmapEditable, tempPoint, storagePoint);
+                    UpdatePixel(stateDirection, bitmapOverlayEditable, tempPoint, storagePoint);
+                }
+            }
+
+
+            pointsStorage = new Dictionary<StateDirection, Dictionary<Point, Point>>();
+        }
+
+
+
+
+
+
+
+
+
+
+
+        /// <summary>
+        /// Get an array of keys from pointStorage with pointOffset.
+        /// </summary>
+        public static Point[] GetStoragePoints(StateDirection stateDirection)
+        {
+            if(pointsStorage.Count == 0)
+                return new Point[0];
+            return pointsStorage[stateDirection].Keys.Select(point => new Point(point.X + pointOffset.X, point.Y + pointOffset.Y)).ToArray();
+        }
+
+        /// <summary>
+        /// Set selected points using picked point and update the Data Pixel Storage.
+        /// </summary>
+        /// <param name="points"></param>
+        public static void UpdateStoragePoints(Point[] points)
+        {
+            var stateDirections = StatesController.GetStateDirections();
+            var cellsSize = EnvironmentController.dataImageState.imageCellsSize;
+
+            pointsStorage = pointsStorage ?? new Dictionary<StateDirection, Dictionary<Point, Point>>();
+
+            foreach (var stateDirection in stateDirections)
+            {
+                pointsStorage[stateDirection] = new Dictionary<Point, Point>();
+                foreach (var point in points)
+                {
+                    Point tempPoint = CorrectMousePositionPoint(stateDirection, point, cellsSize);
+                    Point storagePoint = EnvironmentController.dataPixelStorage.GetPointStorage(stateDirection, point);
+                    pointsStorage[stateDirection][tempPoint] = storagePoint;
+                }
+                //string pointStoragePoints = string.Join(", ", GetStoragePoints(stateDirection));
+                //Debug.WriteLine($"StoragePoints: {stateDirection}: {pointStoragePoints}");
+            }
+        }
+
+
+        private static Point pointOffsetLast = new Point(0, 0);
+
+        public static void ViewSelectedPoints(Point[] points)
+        {
+            //if (pickedPoint.X < 0 || pickedPoint.Y < 0) return;
+
+            if (pointOffset.X == 0 && pointOffset.Y == 0) return;
+            if (pointOffsetLast.X == pointOffset.X && pointOffsetLast.Y == pointOffset.Y) return;
+            pointOffsetLast = pointOffset;
+
+            var cellsSize = EnvironmentController.dataImageState.imageCellsSize;
+            int pixelSize = EnvironmentController.dataImageState.pixelSize;
+            var stateDirections = StatesController.GetStateDirections();
+
+            //pointColorStorage 
+
+            //byte alpha = 100;
+
+            foreach (var stateDirection in stateDirections)
+            {
+                WriteableBitmap bitmap = EnvironmentController.GetSelectorBMP(stateDirection, StateImageSideType.Right);
+
+                WriteableBitmap bitmapPreview = EnvironmentController.GetPreviewBMP(stateDirection, StateImageSideType.Left);
+                WriteableBitmap bitmapOverlayPreview = EnvironmentController.GetOverlayBMP(stateDirection, StateImageSideType.Left);
+
+                foreach (Point point in points)
+                {
+                    Point tempPoint = EnvironmentController.dataPixelStorage.GetPointStorage(stateDirection, point);
+                    tempPoint = CorrectMousePositionPoint(stateDirection, tempPoint, cellsSize);
+                    //Debug.WriteLine($"point: {point}, tempPoint: {tempPoint} --- offset: {pointOffset}, offsetDown: {pointOffsetDown}, offsetMin: {pointOffsetMin}, offsetMax: {pointOffsetMax}");
+
+                    Color color = bitmapOverlayPreview != null ? GetPointColor(bitmapOverlayPreview, tempPoint) : GetPointColor(bitmapPreview, tempPoint);
+                    if (color.A == 0 || color == Colors.Transparent)
+                        color = GetPointColor(bitmapPreview, tempPoint);
+                    //color.A = Math.Min(alpha, color.A);
+                    //color = Colors.Aqua;
+
+                    //tempPoint.X += stateDirection == StateDirection.North ? -5 : 5; // !!!!!!!!! TEST
+
+                    bitmap.FillRectangle(
+                        tempPoint.X * pixelSize + 1, 
+                        tempPoint.Y * pixelSize + 1, 
+                        tempPoint.X * pixelSize + pixelSize, 
+                        tempPoint.Y * pixelSize + pixelSize, 
+                        color);
+                }
+            }
+        }
+
+        //public static void MoveSelectedPoints()
+        //{
+        //    if (pointOffset.X == 0 && pointOffset.Y == 0) return;
+        //}
+
+        //public static void SetSelectedPoints()
+        //{
+        //    if (pointOffset.X == 0 && pointOffset.Y == 0) return;
+        //}
+
+
+
+
+        //if(StatesController.currentStateEditMode == StateEditType.Move || StatesController.currentStateEditMode == StateEditType.Select)
+        //    VisualizeSelectedPoints(stateDirection, bitmap, mousePoint1Temp, pixelSize);
+
+        /// <summary>
+        /// Display all points for better representation of the area coloring.
+        /// </summary>
+        /// <param name="stateDirection"></param>
+        /// <param name="bitmap"></param>
+        /// <param name="point"></param>
+        /// <param name="pixelSize"></param>
+        public static void VisualizeSelectedPoints(StateDirection stateDirection, WriteableBitmap bitmap, Point point, int pixelSize)
+        {
+            // TODO: It needs to be redone.
+            WriteableBitmap bitmapPreview = EnvironmentController.GetPreviewBMP(stateDirection, StateImageSideType.Left);
+            WriteableBitmap bitmapOverlayPreview = EnvironmentController.GetOverlayBMP(stateDirection, StateImageSideType.Left);
+            byte alpha = 100;
+            Color color = bitmapOverlayPreview.GetPixel(point.X, point.Y);
+            color.A = alpha;
+            bitmap.FillRectangle(
+                point.X * pixelSize, 
+                point.Y * pixelSize, 
+                point.X * pixelSize + pixelSize, 
+                point.Y * pixelSize + pixelSize, 
+                color);
+        }
+
+        #endregion Move Selected Area
+
+
+
+
+
 
         /// <summary>
         /// Clear or undo changes to selected points and update the Data Pixel Storage.
@@ -66,9 +348,9 @@ namespace AdaptiveSpritesDMItool.Controllers
         /// <param name="isUndo"></param>
         public static void ClearCurrentPoints(Point[]? points = null, bool isUndo = false)
         {
-            var bitmapSize = EnvironmentController.dataImageState.imageCellsSize;
+            var cellsSize = EnvironmentController.dataImageState.imageCellsSize;
             var stateDirections = StatesController.GetStateDirections();
-            Point mousePos = MouseController.GetCurrentMousePosition();
+            Point mousePos = MouseController.currentMousePosition;
             if (points == null) points = new Point[] { mousePos };
 
             foreach (var stateDirection in stateDirections)
@@ -85,14 +367,14 @@ namespace AdaptiveSpritesDMItool.Controllers
                 foreach (Point point in points)
                 {
                     var pointToColor = point;
-                    pointToColor = CorrectMousePositionPoint(stateDirection, point, bitmapSize);
+                    pointToColor = CorrectMousePositionPoint(stateDirection, point, cellsSize);
                     if (isUndo)
                     {
                         color = bitmapPreview.GetPixel(pointToColor.X, pointToColor.Y);
                         colorOverlay = bitmapOverlayPreview.GetPixel(pointToColor.X, pointToColor.Y);
                     }
-                    UpdatePixel(stateDirection, bitmapEditable, pointToColor, color, !isUndo);
-                    UpdatePixel(stateDirection, bitmapOverlayEditable, pointToColor, colorOverlay, !isUndo);
+                    UpdatePixelPickedPoint(stateDirection, bitmapEditable, pointToColor, color, !isUndo);
+                    UpdatePixelPickedPoint(stateDirection, bitmapOverlayEditable, pointToColor, colorOverlay, !isUndo);
                 }
             }
         }
@@ -130,7 +412,7 @@ namespace AdaptiveSpritesDMItool.Controllers
                 }
             }
         }
-
+        
         /// <summary>
         /// Change the point and update the Data Pixel Storage.
         /// </summary>
@@ -138,10 +420,10 @@ namespace AdaptiveSpritesDMItool.Controllers
         /// <param name="bitmapEditable"></param>
         /// <param name="point"></param>
         /// <param name="color"></param>
-        private static void UpdatePixel(StateDirection stateDirection, WriteableBitmap bitmapEditable, Point point, Color color, bool isRemove = false)
+        private static void UpdatePixelPickedPoint(StateDirection stateDirection, WriteableBitmap bitmapEditable, Point point, Color color, bool isRemove = false)
         {
             bitmapEditable.SetPixel(point.X, point.Y, color);
-            Point newPoint = pickedPoint;
+            Point newPoint = pickedPointFromPreview;
             //if (color == Colors.Transparent)
             if (isRemove)
             {
@@ -151,16 +433,31 @@ namespace AdaptiveSpritesDMItool.Controllers
             EnvironmentController.dataPixelStorage.ChangePoint(stateDirection, (point.X, point.Y), (newPoint.X, newPoint.Y));
         }
 
+
+        private static void UpdatePixel(StateDirection stateDirection, WriteableBitmap bitmapEditable, Point pointKey, Point pointValue)
+        {
+            Color color = bitmapEditable.GetPixel(pointKey.X, pointKey.Y);
+            bitmapEditable.SetPixel(pointValue.X, pointValue.Y, color);
+            EnvironmentController.dataPixelStorage.ChangePoint(stateDirection, (pointKey.X, pointKey.Y), (pointValue.X, pointValue.Y));
+        }
+
+
         /// <summary>
-        /// Get color from a pixel in the selected bitmap.
+        /// Get color from picked point in bitmap.
         /// </summary>
         /// <param name="bitmap"></param>
         /// <returns></returns>
-        public static Color GetPickedPointColor(WriteableBitmap bitmap) => bitmap.GetPixel(pickedPoint.X, pickedPoint.Y);
+        public static Color GetPickedPointColor(WriteableBitmap bitmap) => GetPointColor(bitmap, pickedPointFromPreview);
+
+        /// <summary>
+        /// Get color from point in bitmap.
+        /// </summary>
+        /// <param name="bitmap"></param>
+        /// <returns></returns>
+        public static Color GetPointColor(WriteableBitmap bitmap, Point point) => bitmap.GetPixel(point.X, point.Y);
 
 
         #endregion Draw
-
 
         #region Grids
         /// <summary>
@@ -168,12 +465,12 @@ namespace AdaptiveSpritesDMItool.Controllers
         /// </summary>
         /// <param name="borderThickness"></param>
         /// <returns></returns>
-        public static WriteableBitmap GetNewGrid(int borderThickness = 2)
+        public static WriteableBitmap GetNewGrid()
         {
             int pixelSize = EnvironmentController.dataImageState.pixelSize;
             Color color = EnvironmentController.GetGridColor();
-            System.Drawing.Size bitmapSize = EnvironmentController.dataImageState.bitmapUISize;
-            WriteableBitmap bitmap = new WriteableBitmap(bitmapSize.Width, bitmapSize.Height, pixelSize, pixelSize, PixelFormats.Bgra32, null);
+            System.Drawing.Size cellsSize = EnvironmentController.dataImageState.bitmapUISize;
+            WriteableBitmap bitmap = new WriteableBitmap(cellsSize.Width, cellsSize.Height, pixelSize, pixelSize, PixelFormats.Bgra32, null);
 
             for (int i = 0; i < bitmap.PixelWidth; i += pixelSize)
             {
@@ -204,7 +501,7 @@ namespace AdaptiveSpritesDMItool.Controllers
         /// </summary>
         /// <param name="stateImageSideType"></param>
         /// <param name="mousePoint"></param>
-        public static void SetSelectors(StateImageSideType stateImageSideType, Point mousePoint) => SetSelectors(stateImageSideType, mousePoint, mousePoint);
+        public static void ViewSelectors(StateImageSideType stateImageSideType, Point mousePoint) => ViewSelectors(stateImageSideType, mousePoint, mousePoint);
 
         /// <summary>
         /// Selector with dotted lines.
@@ -212,21 +509,21 @@ namespace AdaptiveSpritesDMItool.Controllers
         /// <param name="stateImageSideType"></param>
         /// <param name="mousePoint1"></param>
         /// <param name="mousePoint2"></param>
-        public static void SetSelectors(StateImageSideType stateImageSideType, Point mousePoint1, Point mousePoint2)
+        public static void ViewSelectors(StateImageSideType stateImageSideType, Point mousePoint1, Point mousePoint2)
         {
             int pixelSize = EnvironmentController.dataImageState.pixelSize;
             System.Drawing.Size imageSize = EnvironmentController.dataImageState.imageCellsSize;
-            var stateDirectionsAll = StatesController.GetStateDirections();
+            var stateDirections = StatesController.GetStateDirections();
 
-            foreach (StateDirection stateDirection in stateDirectionsAll)
+            foreach (StateDirection stateDirection in stateDirections)
             {
                 WriteableBitmap bitmap = EnvironmentController.GetSelectorBMP(stateDirection, stateImageSideType);
-                bitmap.Clear();
 
                 var mousePoint1Temp = CorrectMousePositionPoint(stateDirection, mousePoint1, imageSize);
                 var mousePoint2Temp = CorrectMousePositionPoint(stateDirection, mousePoint2, imageSize);
 
                 DrawSelectionRect(bitmap, mousePoint1Temp, mousePoint2Temp, pixelSize);
+
                 StatesController.stateSourceDictionary[stateDirection][StateImageType.Selection][stateImageSideType].Source = bitmap;
             }
         }
@@ -237,7 +534,7 @@ namespace AdaptiveSpritesDMItool.Controllers
         /// <param name="_stateImageSideType"></param>
         public static void ClearSelectors(StateImageSideType _stateImageSideType)
         {
-            var stateDirections = StatesController.allStateDirection(DirectionDepth.Four);
+            var stateDirections = StatesController.allStateDirection();
             foreach (StateDirection stateDirection in stateDirections)
             {
                 WriteableBitmap bitmap = EnvironmentController.dataImageState.stateBMPdict[stateDirection][StateImageType.Selection][_stateImageSideType];
@@ -250,7 +547,7 @@ namespace AdaptiveSpritesDMItool.Controllers
         /// </summary>
         public static void ClearSelectors()
         {
-            var stateDirections = StatesController.allStateDirection(DirectionDepth.Four);
+            var stateDirections = StatesController.allStateDirection();
 
             foreach (StateDirection stateDirection in stateDirections)
             {
@@ -363,24 +660,6 @@ namespace AdaptiveSpritesDMItool.Controllers
             bitmap.FillRectangle(point2.X * pixelSize, point2.Y * pixelSize, point2.X * pixelSize + pixelSize, point2.Y * pixelSize + pixelSize, greenColor);
         }
 
-        /// <summary>
-        /// Display all points for better representation of the area coloring.
-        /// </summary>
-        /// <param name="stateDirection"></param>
-        /// <param name="bitmap"></param>
-        /// <param name="point"></param>
-        /// <param name="pixelSize"></param>
-        public static void VisualizeSelectedPoint(StateDirection stateDirection, WriteableBitmap bitmap, Point point, int pixelSize)
-        {
-            // TODO: It needs to be redone.
-            WriteableBitmap bitmapPreview = EnvironmentController.GetPreviewBMP(stateDirection, StateImageSideType.Left);
-            WriteableBitmap bitmapOverlayPreview = EnvironmentController.GetOverlayBMP(stateDirection, StateImageSideType.Left);
-            byte alpha = 100;
-            Color color = bitmapOverlayPreview.GetPixel(point.X, point.Y);
-            color.A = alpha;
-            bitmap.FillRectangle(point.X * pixelSize, point.Y * pixelSize, point.X * pixelSize + pixelSize, point.Y * pixelSize + pixelSize, color);
-        }
-
         #endregion Visualize
 
 
@@ -392,9 +671,9 @@ namespace AdaptiveSpritesDMItool.Controllers
         /// </summary>
         /// <param name="stateDirection"></param>
         /// <param name="mousePoint"></param>
-        /// <param name="bitmapSize"></param>
+        /// <param name="cellsSize"></param>
         /// <returns></returns>
-        private static Point CorrectMousePositionPoint(StateDirection stateDirection, Point mousePoint, System.Drawing.Size bitmapSize)
+        private static Point CorrectMousePositionPoint(StateDirection stateDirection, Point mousePoint, System.Drawing.Size cellsSize)
         {
             bool isMirroredState = StatesController.isMirroredState;
             bool isStateOpposite = StatesController.isStateOpposite(stateDirection);
@@ -407,9 +686,9 @@ namespace AdaptiveSpritesDMItool.Controllers
                 return mousePoint;
             }
             var additionValueX = StatesController.isCentralizedState ? -1 : 0;
-            int result = bitmapSize.Width - mousePoint.X - 1 + additionValueX;
+            int result = cellsSize.Width - mousePoint.X - 1 + additionValueX;
             result = Math.Max(result, 0);
-            result = Math.Min(result, bitmapSize.Width - 1);
+            result = Math.Min(result, cellsSize.Width - 1);
             Point newMousePoint = new Point(result, mousePoint.Y);
             //Debug.WriteLine($"stateDirection: {stateDirection}: [Orig: {mousePoint} - Mod: {newMousePoint}]");
             return newMousePoint;

--- a/Controllers/EditorController.cs
+++ b/Controllers/EditorController.cs
@@ -24,7 +24,11 @@ namespace AdaptiveSpritesDMItool.Controllers
 {
     internal static class EditorController
     {
+        static SelectMode selectMode = SelectMode.None;
+
         #region Editor Modes
+
+        #region Draw
 
         public static void EditSingleMode(StateImageSideType _stateImageSideType)
         {
@@ -91,6 +95,11 @@ namespace AdaptiveSpritesDMItool.Controllers
             }
         }
 
+        #endregion Draw
+
+
+        #region Clear
+
         public static void EditDeleteMode(StateImageSideType _stateImageSideType)
         {
             switch (_stateImageSideType)
@@ -156,12 +165,10 @@ namespace AdaptiveSpritesDMItool.Controllers
             }
         }
 
+        #endregion Clear
 
 
-
-
-
-
+        #region Select
 
         public static void EditMoveModeStart(StateImageSideType _stateImageSideType)
         {
@@ -176,18 +183,12 @@ namespace AdaptiveSpritesDMItool.Controllers
 
             Point[] selectedPoints = new Point[] { MouseController.currentMousePosition };
             DrawController.UpdateStoragePoints(selectedPoints);
-            //DrawController.SetStoragePoints();
-
             ViewSelectedPoints(_stateImageSideType);
         }
 
         public static void EditMoveMode(StateImageSideType _stateImageSideType)
         {
             if (_stateImageSideType != StateImageSideType.Right) return;
-
-            //var direction = StatesController.currentStateDirection;
-            //var pointsDirection = DrawController.GetStoragePoints(direction);
-            //Point currPos = MouseController.currentMousePosition;
 
             DrawController.UpdatePointOffset();
             ViewSelectedPoints(_stateImageSideType);
@@ -197,23 +198,10 @@ namespace AdaptiveSpritesDMItool.Controllers
         {
             if (_stateImageSideType != StateImageSideType.Right) return;
 
-            Debug.WriteLine("Select Start - Out Points => Select");
-            // Начинаем вновь выделять
             DrawController.SetStoragePoints();
             DrawController.ClearSelectors();
 
         }
-
-
-
-
-
-
-
-
-
-
-        static SelectMode selectMode = SelectMode.None;
 
         public static void EditSelectModeStart(StateImageSideType _stateImageSideType)
         {
@@ -223,8 +211,8 @@ namespace AdaptiveSpritesDMItool.Controllers
                     break;
                 case StateImageSideType.Right:
 
-                    // Если нажата мышь в пределах УЖЕ выделенной области - то
-                    //      Устанавливаем Move - режим перемещения
+                    // If the mouse is pressed within the ALREADY selected area - then:
+                    // Set Move - the movement mode
                     var direction = StatesController.currentStateDirection;
                     var pointsDirection = DrawController.GetStoragePoints(direction);
                     //string pointsString = string.Join(", ", pointsDirection.Select(x => x.ToString()));
@@ -232,14 +220,13 @@ namespace AdaptiveSpritesDMItool.Controllers
                     if (MouseController.isMouseInPoints(pointsDirection))
                     {
                         selectMode = SelectMode.Move;
-                        Debug.WriteLine("Select Start - In Points => Move");
+                        //Debug.WriteLine("Select Start - In Points => Move");
                         DrawController.UpdatePointOffsetDown();
-                        //DrawController.CopySelectedOffsetPoints();
                         break;
                     }
 
-                    Debug.WriteLine("Select Start - Out Points => Select");
-                    // Начинаем вновь выделять
+                    //Debug.WriteLine("Select Start - Out Points => Select");
+                    // Select again
                     selectMode = SelectMode.Select;
                     ViewSelectedPoints(_stateImageSideType);
                     DrawController.SetStoragePoints();
@@ -257,21 +244,16 @@ namespace AdaptiveSpritesDMItool.Controllers
                 case StateImageSideType.Left:
                     break;
                 case StateImageSideType.Right:
-                    //var points = GetPointsFromMouseDownToUp();
-                    //ViewSelectedPoints(_stateImageSideType, points);
-
-                    // Зависимость от режима
-
                     switch(selectMode)
                     {
                         case SelectMode.Select:
-                            // Select - продолжаем выделять область
+                            // Select - continue to select the area
                             //Debug.WriteLine("Select - Select");
                             var points = GetPointsFromMouseDownToUp();
                             ViewSelectedPoints(_stateImageSideType, points);
                             break;
                         case SelectMode.Move:
-                            // Move - двигаем изображение
+                            // Move - move the area
                             //Debug.WriteLine("Select - Move");
                             DrawController.UpdatePointOffset();
                             ViewSelectedPoints(_stateImageSideType);
@@ -282,19 +264,12 @@ namespace AdaptiveSpritesDMItool.Controllers
             }
         }
 
-
-
-
-
-
-
-
         public static void EditSelectModeEnd(StateImageSideType _stateImageSideType)
         {
             Point[] selectedPoints = GetPointsFromMouseDownToUp();
             if (selectedPoints.Length <= 1)
             {
-                Debug.WriteLine("Select End - Finish");
+                //Debug.WriteLine("Select End - Finish");
                 selectMode = SelectMode.None;
                 DrawController.ClearSelectors();
                 return;
@@ -308,19 +283,17 @@ namespace AdaptiveSpritesDMItool.Controllers
                     switch (selectMode)
                     {
                         case SelectMode.Select:
-                            Debug.WriteLine("Select End - Select");
-                            // Select - Завершаем выделение области, сохраняем Picked Points
+                            //Debug.WriteLine("Select End - Select");
+                            // Select - Complete the selection of the area, save the Picked Points
                             //var direction = StatesController.currentStateDirection;
                             //string pointsString = string.Join(", ", selectedPoints.Select(x => x.ToString()));
                             //Debug.WriteLine($"UpdateStoragePoints[{direction}][{selectedPoints.Length}]: {pointsString}");
                             DrawController.UpdateStoragePoints(selectedPoints);
-                            // Определяем границы оффсета для SelectMode.Move
+                            // Define offset boundaries for SelectMode.Move
                             DrawController.UpdatePointOffsetBounds(MouseController.currentMouseDownPosition, MouseController.currentMousePosition);
                             break;
                         case SelectMode.Move:
-                            Debug.WriteLine("Select End - Move");
-                            // Move - Отпускаем изображение
-                            //Point[] checkPoints = DrawController.GetStoragePoints(StatesController.currentStateDirection);
+                            //Debug.WriteLine("Select End - Move");
                             break;
                     }
 
@@ -328,11 +301,37 @@ namespace AdaptiveSpritesDMItool.Controllers
             }
         }
 
+        #endregion Select
 
 
+        public static void EditWhenEnterImage(StateImageSideType _stateImageSideType)
+        {
+            DrawController.ClearSelectors();
+        }
+
+        #endregion Editor Modes
 
 
+        #region Editor View
 
+        private static void ViewMultSelectorAtCurrentToMDownPosition(StateImageSideType stateImageSideType, bool isNeedClear = true)
+        {
+            ViewMultSelectorAtPoints(stateImageSideType, MouseController.currentMouseDownPosition, MouseController.currentMousePosition, isNeedClear);
+        }
+
+        private static void ViewSingleSelectorAtCurrentPosition(StateImageSideType stateImageSideType, bool isNeedClear = true)
+        {
+            ViewMultSelectorAtPoints(stateImageSideType, MouseController.currentMousePosition, MouseController.currentMousePosition, isNeedClear);
+        }
+
+        private static void ViewMultSelectorAtPoints(StateImageSideType stateImageSideType, Point point1, Point point2, bool isNeedClear = true)
+        {
+            if (!MouseController.isMouseInImage)
+                return;
+            if (isNeedClear)
+                DrawController.ClearSelectors(stateImageSideType);
+            DrawController.ViewSelectors(stateImageSideType, point1, point2);
+        }
 
         private static void ViewSelectedPoints(StateImageSideType _stateImageSideType) => ViewSelectedPoints(_stateImageSideType, new Point[] { MouseController.currentMousePosition });
 
@@ -368,40 +367,6 @@ namespace AdaptiveSpritesDMItool.Controllers
                     ViewMultSelectorAtPoints(_stateImageSideType, point1, point2, false);
                     break;
             }
-        }
-
-
-
-
-
-
-        public static void EditWhenEnterImage(StateImageSideType _stateImageSideType)
-        {
-            DrawController.ClearSelectors();
-        }
-
-        #endregion Editor Modes
-
-
-        #region Editor View
-
-        private static void ViewMultSelectorAtCurrentToMDownPosition(StateImageSideType stateImageSideType, bool isNeedClear = true)
-        {
-            ViewMultSelectorAtPoints(stateImageSideType, MouseController.currentMouseDownPosition, MouseController.currentMousePosition, isNeedClear);
-        }
-
-        private static void ViewSingleSelectorAtCurrentPosition(StateImageSideType stateImageSideType, bool isNeedClear = true)
-        {
-            ViewMultSelectorAtPoints(stateImageSideType, MouseController.currentMousePosition, MouseController.currentMousePosition, isNeedClear);
-        }
-
-        private static void ViewMultSelectorAtPoints(StateImageSideType stateImageSideType, Point point1, Point point2, bool isNeedClear = true)
-        {
-            if (!MouseController.isMouseInImage)
-                return;
-            if (isNeedClear)
-                DrawController.ClearSelectors(stateImageSideType);
-            DrawController.ViewSelectors(stateImageSideType, point1, point2);
         }
 
         private static void PickPointAtCurrentPosition()

--- a/Controllers/EditorController.cs
+++ b/Controllers/EditorController.cs
@@ -239,8 +239,8 @@ namespace AdaptiveSpritesDMItool.Controllers
                     // Начинаем вновь выделять
                     selectMode = SelectMode.Select;
                     ViewSelectedPoints(_stateImageSideType);
-                    DrawController.ShiftOffset();
-
+                    DrawController.SetStoragePoints();
+                    DrawController.ResetOffset();
                     //UpdatePixel
 
                     break;
@@ -272,20 +272,8 @@ namespace AdaptiveSpritesDMItool.Controllers
                         case SelectMode.Move:
                             // Move - двигаем изображение
                             //Debug.WriteLine("Select - Move");
-
-                            // Обновляем оффсет точку
                             DrawController.UpdatePointOffset();
                             ViewSelectedPoints(_stateImageSideType);
-                            //DrawController.WriteSelectedOffsetPoints();
-
-
-                            // Показываем выделенные поинты
-                            //Point[] pickedPoints = DrawController.GetStoragePoints(StatesController.currentStateDirection);
-                            //ViewSelectedPoints(_stateImageSideType, pickedPoints);
-
-
-                            // !!!!!!!!!! ДВИГАЕМ БИТМАП ИЗОБРАЖЕНИЕ !!!!!!!!!!!!
-                            // !!!!! WRITE PIXELS !!!!!
                             break;
                     }
 

--- a/Controllers/EditorController.cs
+++ b/Controllers/EditorController.cs
@@ -358,23 +358,17 @@ namespace AdaptiveSpritesDMItool.Controllers
 
         private static void ViewSelectedPoints(StateImageSideType _stateImageSideType, Point[] points)
         {
-            DrawController.ClearSelectors();
             switch (selectMode)
             {
                 case SelectMode.None:
                     break;
                 case SelectMode.Select:
-                    if(points.Length <= 1)
-                        ViewSingleSelectorAtCurrentPosition(_stateImageSideType, false);
+                    if (points.Length <= 1)
+                        ViewSingleSelectorAtCurrentPosition(_stateImageSideType);
                     else
-                        ViewMultSelectorAtCurrentToMDownPosition(_stateImageSideType, false);
+                        ViewMultSelectorAtCurrentToMDownPosition(_stateImageSideType);
                     break;
                 case SelectMode.Move:
-                    //if (points.Length <= 1)
-                    //    ViewSingleSelectorAtCurrentPosition(_stateImageSideType, false);
-                    //else
-                    //{
-                    //}
                     Point point1 = DrawController.pointOffsetMin;
                     point1.X += DrawController.pointOffset.X;
                     point1.Y += DrawController.pointOffset.Y;

--- a/Controllers/EditorController.cs
+++ b/Controllers/EditorController.cs
@@ -39,7 +39,7 @@ namespace AdaptiveSpritesDMItool.Controllers
                     PickPointAtCurrentPosition();
                     break;
                 case StateImageSideType.Right:
-                    DrawController.SetPickedPoints();
+                    DrawController.SetPickedPoint();
                     break;
             }
         }
@@ -85,7 +85,7 @@ namespace AdaptiveSpritesDMItool.Controllers
                     if (MouseController.currentMouseDownPosition != MouseController.currentMousePosition)
                     {
                         var points = GetPointsFromMouseDownToUp();
-                        DrawController.SetPickedPoints(points);
+                        DrawController.SetPickedPoint(points);
                     }
                     break;
             }
@@ -124,7 +124,6 @@ namespace AdaptiveSpritesDMItool.Controllers
                 case StateImageSideType.Left:
                     break;
                 case StateImageSideType.Right:
-                    DrawController.ClearSelectors();
                     ViewSingleSelectorAtCurrentPosition(_stateImageSideType);
                     DrawController.ClearCurrentPoints(isUndo: true);
                     break;
@@ -157,42 +156,12 @@ namespace AdaptiveSpritesDMItool.Controllers
             }
         }
 
-        public static void EditSelectModeStart(StateImageSideType _stateImageSideType)
-        {
-            switch (_stateImageSideType)
-            {
-                case StateImageSideType.Left:
-                    break;
-                case StateImageSideType.Right:
-                    DrawController.ClearSelectors();
-                    ViewSingleSelectorAtCurrentPosition(_stateImageSideType);
-                    break;
-            }
-        }
 
-        public static void EditSelectMode(StateImageSideType _stateImageSideType)
-        {
-            switch (_stateImageSideType)
-            {
-                case StateImageSideType.Left:
-                    break;
-                case StateImageSideType.Right:
-                    ViewMultSelectorAtCurrentToMDownPosition(_stateImageSideType);
-                    break;
-            }
-        }
 
-        public static void EditSelectModeEnd(StateImageSideType _stateImageSideType)
-        {
-            //ClearSelectors();
-            switch (_stateImageSideType)
-            {
-                case StateImageSideType.Left:
-                    break;
-                case StateImageSideType.Right:
-                    break;
-            }
-        }
+
+
+
+
 
         public static void EditMoveMode(StateImageSideType _stateImageSideType)
         {
@@ -201,10 +170,229 @@ namespace AdaptiveSpritesDMItool.Controllers
                 case StateImageSideType.Left:
                     break;
                 case StateImageSideType.Right:
-                    ViewSingleSelectorAtCurrentPosition(_stateImageSideType);
+                    //ViewSelectedPoints(_stateImageSideType);
+                    //DrawController.ClearSelectors();
+                    //DrawController.ViewSelectedPoints(points);
+                    //ViewSingleSelectorAtCurrentPosition(_stateImageSideType, false);
+                    
+                    //EditSelectModeStart(_stateImageSideType);
                     break;
             }
         }
+
+
+
+
+
+        static SelectMode selectMode = SelectMode.None;
+
+        public static void EditSelectModeStart(StateImageSideType _stateImageSideType)
+        {
+            switch (_stateImageSideType)
+            {
+                case StateImageSideType.Left:
+                    break;
+                case StateImageSideType.Right:
+
+                    // Если нажата мышь в пределах УЖЕ выделенной области - то
+                    //      Устанавливаем Move - режим перемещения
+                    var direction = StatesController.currentStateDirection;
+                    var pointsDirection = DrawController.GetStoragePoints(direction);
+                    //string pointsString = string.Join(", ", pointsDirection.Select(x => x.ToString()));
+                    //Debug.WriteLine($"pointsDirection[{direction}][{pointsDirection.Length}]: {pointsString}");
+                    if (MouseController.isMouseInPoints(pointsDirection))
+                    {
+                        selectMode = SelectMode.Move;
+                        Debug.WriteLine("Select Start - In Points => Move");
+                        DrawController.UpdatePointOffsetDown();
+                        //DrawController.CopySelectedOffsetPoints();
+                        break;
+                    }
+
+                    // Если нажата мышь ЗА пределами - то режим:
+                    //      Устанавливаем Select для создания новой выборки
+
+                    // Делаем сброс и очищаем полотно. Всё заного.
+                    // !!!!!! Сделать потом проверку нажато ли 1 раз и только тогда сбрасывать, иначе разрешить выделение !!!!!!
+                    //if (selectMode == SelectMode.Select)
+                    //{
+                    //    Debug.WriteLine("Select Start - Out Points - Select => None");
+                    //    selectMode = SelectMode.None;
+                    //    DrawController.ClearSelectors();
+                    //    break;
+                    //}
+
+                    // Завершаем двигание объекта. Сохраняем перемещенные точки на полотно.
+                    //if (selectMode == SelectMode.Move)
+                    //{
+                    //    Debug.WriteLine("Select Start - Out Points - Move");
+                    //    // !!!!!!!! УСТАНАВЛИВАЕМ ПЕРЕМЕЩЕННОЕ ИЗОБРАЖЕНИЕ И ПОИНТЫ !!!!!!
+                    //    // !!!!! COPY PIXELS !!!!!
+                    //    // Делаем сброс и очищаем полотно.
+                    //    selectMode = SelectMode.None;
+                    //    DrawController.ClearSelectors();
+                    //    DrawController.ShiftOffset();
+                    //    break;
+                    //}
+
+                    Debug.WriteLine("Select Start - Out Points => Select");
+                    // Начинаем вновь выделять
+                    selectMode = SelectMode.Select;
+                    ViewSelectedPoints(_stateImageSideType);
+                    DrawController.ShiftOffset();
+
+                    //UpdatePixel
+
+                    break;
+            }
+        }
+
+
+
+        public static void EditSelectMode(StateImageSideType _stateImageSideType)
+        {
+            switch (_stateImageSideType)
+            {
+                case StateImageSideType.Left:
+                    break;
+                case StateImageSideType.Right:
+                    //var points = GetPointsFromMouseDownToUp();
+                    //ViewSelectedPoints(_stateImageSideType, points);
+
+                    // Зависимость от режима
+
+                    switch(selectMode)
+                    {
+                        case SelectMode.Select:
+                            // Select - продолжаем выделять область
+                            //Debug.WriteLine("Select - Select");
+                            var points = GetPointsFromMouseDownToUp();
+                            ViewSelectedPoints(_stateImageSideType, points);
+                            break;
+                        case SelectMode.Move:
+                            // Move - двигаем изображение
+                            //Debug.WriteLine("Select - Move");
+
+                            // Обновляем оффсет точку
+                            DrawController.UpdatePointOffset();
+                            ViewSelectedPoints(_stateImageSideType);
+                            //DrawController.WriteSelectedOffsetPoints();
+
+
+                            // Показываем выделенные поинты
+                            //Point[] pickedPoints = DrawController.GetStoragePoints(StatesController.currentStateDirection);
+                            //ViewSelectedPoints(_stateImageSideType, pickedPoints);
+
+
+                            // !!!!!!!!!! ДВИГАЕМ БИТМАП ИЗОБРАЖЕНИЕ !!!!!!!!!!!!
+                            // !!!!! WRITE PIXELS !!!!!
+                            break;
+                    }
+
+                    break;
+            }
+        }
+
+
+
+
+
+
+
+
+        public static void EditSelectModeEnd(StateImageSideType _stateImageSideType)
+        {
+            Point[] selectedPoints = GetPointsFromMouseDownToUp();
+            if (selectedPoints.Length <= 1)
+            {
+                Debug.WriteLine("Select End - Finish");
+                selectMode = SelectMode.None;
+                DrawController.ClearSelectors();
+                return;
+            }
+
+            switch (_stateImageSideType)
+            {
+                case StateImageSideType.Left:
+                    break;
+                case StateImageSideType.Right:
+                    switch (selectMode)
+                    {
+                        case SelectMode.Select:
+                            Debug.WriteLine("Select End - Select");
+                            // Select - Завершаем выделение области, сохраняем Picked Points
+                            var direction = StatesController.currentStateDirection;
+                            string pointsString = string.Join(", ", selectedPoints.Select(x => x.ToString()));
+                            Debug.WriteLine($"UpdateStoragePoints[{direction}][{selectedPoints.Length}]: {pointsString}");
+                            DrawController.UpdateStoragePoints(selectedPoints);
+                            // Определяем границы оффсета для SelectMode.Move
+                            DrawController.UpdatePointOffsetBounds(MouseController.currentMouseDownPosition, MouseController.currentMousePosition);
+                            break;
+                        case SelectMode.Move:
+                            Debug.WriteLine("Select End - Move");
+                            // Move - Отпускаем изображение
+                            //Point[] checkPoints = DrawController.GetStoragePoints(StatesController.currentStateDirection);
+                            break;
+                    }
+
+                    break;
+            }
+        }
+
+
+
+
+        //private static void 
+
+
+
+
+
+
+
+
+
+
+
+        private static void ViewSelectedPoints(StateImageSideType _stateImageSideType) => ViewSelectedPoints(_stateImageSideType, new Point[] { MouseController.currentMousePosition });
+
+        private static void ViewSelectedPoints(StateImageSideType _stateImageSideType, Point[] points)
+        {
+            DrawController.ClearSelectors();
+            switch (selectMode)
+            {
+                case SelectMode.None:
+                    break;
+                case SelectMode.Select:
+                    if(points.Length <= 1)
+                        ViewSingleSelectorAtCurrentPosition(_stateImageSideType, false);
+                    else
+                        ViewMultSelectorAtCurrentToMDownPosition(_stateImageSideType, false);
+                    break;
+                case SelectMode.Move:
+                    //if (points.Length <= 1)
+                    //    ViewSingleSelectorAtCurrentPosition(_stateImageSideType, false);
+                    //else
+                    //{
+                    //}
+                    Point point1 = DrawController.pointOffsetMin;
+                    point1.X += DrawController.pointOffset.X;
+                    point1.Y += DrawController.pointOffset.Y;
+                    Point point2 = DrawController.pointOffsetMax;
+                    point2.X += DrawController.pointOffset.X;
+                    point2.Y += DrawController.pointOffset.Y;
+
+                    var pointsDirection = DrawController.GetStoragePoints(StatesController.currentStateDirection);
+                    DrawController.ViewSelectedPoints(pointsDirection);
+                    ViewMultSelectorAtPoints(_stateImageSideType, point1, point2, false);
+                    break;
+            }
+        }
+
+
+
+
+
 
         public static void EditWhenEnterImage(StateImageSideType _stateImageSideType)
         {
@@ -216,22 +404,30 @@ namespace AdaptiveSpritesDMItool.Controllers
 
         #region Editor View
 
-        private static void ViewMultSelectorAtCurrentToMDownPosition(StateImageSideType stateImageSideType)
+        private static void ViewMultSelectorAtCurrentToMDownPosition(StateImageSideType stateImageSideType, bool isNeedClear = true)
         {
-            if (MouseController.isMouseInImage)
-                DrawController.SetSelectors(stateImageSideType, MouseController.currentMouseDownPosition, MouseController.currentMousePosition);
+            ViewMultSelectorAtPoints(stateImageSideType, MouseController.currentMouseDownPosition, MouseController.currentMousePosition, isNeedClear);
         }
 
-        private static void ViewSingleSelectorAtCurrentPosition(StateImageSideType stateImageSideType)
+        private static void ViewSingleSelectorAtCurrentPosition(StateImageSideType stateImageSideType, bool isNeedClear = true)
         {
-            if (MouseController.isMouseInImage)
-                DrawController.SetSelectors(stateImageSideType, MouseController.currentMousePosition);
+            ViewMultSelectorAtPoints(stateImageSideType, MouseController.currentMousePosition, MouseController.currentMousePosition, isNeedClear);
+        }
+
+        private static void ViewMultSelectorAtPoints(StateImageSideType stateImageSideType, Point point1, Point point2, bool isNeedClear = true)
+        {
+            if (!MouseController.isMouseInImage)
+                return;
+            if (isNeedClear)
+                DrawController.ClearSelectors(stateImageSideType);
+            DrawController.ViewSelectors(stateImageSideType, point1, point2);
         }
 
         private static void PickPointAtCurrentPosition()
         {
-            if (MouseController.isMouseInImage)
-                DrawController.pickedPoint = MouseController.currentMousePosition;
+            if (!MouseController.isMouseInImage)
+                return;
+            DrawController.pickedPointFromPreview = MouseController.currentMousePosition;
         }
 
         #endregion Editor View
@@ -262,16 +458,18 @@ namespace AdaptiveSpritesDMItool.Controllers
             return bitmap;
         }
 
+        private static Point[] GetPointsFromMouseDownToUp() => GetPointsFromTo(MouseController.currentMouseDownPosition, MouseController.currentMousePosition);
+
         /// <summary>
         /// Get points from mouse down position to mouse up position
         /// </summary>
         /// <returns></returns>
-        private static Point[] GetPointsFromMouseDownToUp()
+        private static Point[] GetPointsFromTo(Point point1, Point point2)
         {
-            int x1 = Math.Min(MouseController.currentMouseDownPosition.X, MouseController.currentMousePosition.X);
-            int x2 = Math.Max(MouseController.currentMouseDownPosition.X, MouseController.currentMousePosition.X);
-            int y1 = Math.Min(MouseController.currentMouseDownPosition.Y, MouseController.currentMousePosition.Y);
-            int y2 = Math.Max(MouseController.currentMouseDownPosition.Y, MouseController.currentMousePosition.Y);
+            int x1 = Math.Min(point1.X, point2.X);
+            int x2 = Math.Max(point1.X, point2.X);
+            int y1 = Math.Min(point1.Y, point2.Y);
+            int y2 = Math.Max(point1.Y, point2.Y);
 
             var points = new Point[(x2 - x1 + 1) * (y2 - y1 + 1)];
             int pointIndex = 0;

--- a/Controllers/EditorController.cs
+++ b/Controllers/EditorController.cs
@@ -163,22 +163,51 @@ namespace AdaptiveSpritesDMItool.Controllers
 
 
 
+        public static void EditMoveModeStart(StateImageSideType _stateImageSideType)
+        {
+            if (_stateImageSideType != StateImageSideType.Right) return;
+
+            selectMode = SelectMode.Move;
+            Point currPos = MouseController.currentMousePosition;
+            DrawController.pointOffsetDown = currPos;
+            DrawController.pointOffsetMin = currPos;
+            DrawController.pointOffsetMax = currPos;
+            DrawController.pointOffset = new Point(0, 0);
+
+            Point[] selectedPoints = new Point[] { MouseController.currentMousePosition };
+            DrawController.UpdateStoragePoints(selectedPoints);
+            //DrawController.SetStoragePoints();
+
+            ViewSelectedPoints(_stateImageSideType);
+        }
+
         public static void EditMoveMode(StateImageSideType _stateImageSideType)
         {
-            switch (_stateImageSideType)
-            {
-                case StateImageSideType.Left:
-                    break;
-                case StateImageSideType.Right:
-                    //ViewSelectedPoints(_stateImageSideType);
-                    //DrawController.ClearSelectors();
-                    //DrawController.ViewSelectedPoints(points);
-                    //ViewSingleSelectorAtCurrentPosition(_stateImageSideType, false);
-                    
-                    //EditSelectModeStart(_stateImageSideType);
-                    break;
-            }
+            if (_stateImageSideType != StateImageSideType.Right) return;
+
+            //var direction = StatesController.currentStateDirection;
+            //var pointsDirection = DrawController.GetStoragePoints(direction);
+            //Point currPos = MouseController.currentMousePosition;
+
+            DrawController.UpdatePointOffset();
+            ViewSelectedPoints(_stateImageSideType);
         }
+
+        public static void EditMoveModeEnd(StateImageSideType _stateImageSideType)
+        {
+            if (_stateImageSideType != StateImageSideType.Right) return;
+
+            Debug.WriteLine("Select Start - Out Points => Select");
+            // Начинаем вновь выделять
+            DrawController.SetStoragePoints();
+            DrawController.ClearSelectors();
+
+        }
+
+
+
+
+
 
 
 
@@ -209,40 +238,12 @@ namespace AdaptiveSpritesDMItool.Controllers
                         break;
                     }
 
-                    // Если нажата мышь ЗА пределами - то режим:
-                    //      Устанавливаем Select для создания новой выборки
-
-                    // Делаем сброс и очищаем полотно. Всё заного.
-                    // !!!!!! Сделать потом проверку нажато ли 1 раз и только тогда сбрасывать, иначе разрешить выделение !!!!!!
-                    //if (selectMode == SelectMode.Select)
-                    //{
-                    //    Debug.WriteLine("Select Start - Out Points - Select => None");
-                    //    selectMode = SelectMode.None;
-                    //    DrawController.ClearSelectors();
-                    //    break;
-                    //}
-
-                    // Завершаем двигание объекта. Сохраняем перемещенные точки на полотно.
-                    //if (selectMode == SelectMode.Move)
-                    //{
-                    //    Debug.WriteLine("Select Start - Out Points - Move");
-                    //    // !!!!!!!! УСТАНАВЛИВАЕМ ПЕРЕМЕЩЕННОЕ ИЗОБРАЖЕНИЕ И ПОИНТЫ !!!!!!
-                    //    // !!!!! COPY PIXELS !!!!!
-                    //    // Делаем сброс и очищаем полотно.
-                    //    selectMode = SelectMode.None;
-                    //    DrawController.ClearSelectors();
-                    //    DrawController.ShiftOffset();
-                    //    break;
-                    //}
-
                     Debug.WriteLine("Select Start - Out Points => Select");
                     // Начинаем вновь выделять
                     selectMode = SelectMode.Select;
                     ViewSelectedPoints(_stateImageSideType);
                     DrawController.SetStoragePoints();
                     DrawController.ResetOffset();
-                    //UpdatePixel
-
                     break;
             }
         }
@@ -309,9 +310,9 @@ namespace AdaptiveSpritesDMItool.Controllers
                         case SelectMode.Select:
                             Debug.WriteLine("Select End - Select");
                             // Select - Завершаем выделение области, сохраняем Picked Points
-                            var direction = StatesController.currentStateDirection;
-                            string pointsString = string.Join(", ", selectedPoints.Select(x => x.ToString()));
-                            Debug.WriteLine($"UpdateStoragePoints[{direction}][{selectedPoints.Length}]: {pointsString}");
+                            //var direction = StatesController.currentStateDirection;
+                            //string pointsString = string.Join(", ", selectedPoints.Select(x => x.ToString()));
+                            //Debug.WriteLine($"UpdateStoragePoints[{direction}][{selectedPoints.Length}]: {pointsString}");
                             DrawController.UpdateStoragePoints(selectedPoints);
                             // Определяем границы оффсета для SelectMode.Move
                             DrawController.UpdatePointOffsetBounds(MouseController.currentMouseDownPosition, MouseController.currentMousePosition);
@@ -326,15 +327,6 @@ namespace AdaptiveSpritesDMItool.Controllers
                     break;
             }
         }
-
-
-
-
-        //private static void 
-
-
-
-
 
 
 
@@ -357,6 +349,15 @@ namespace AdaptiveSpritesDMItool.Controllers
                         ViewMultSelectorAtCurrentToMDownPosition(_stateImageSideType);
                     break;
                 case SelectMode.Move:
+                    var pointsDirection = DrawController.GetStoragePoints(StatesController.currentStateDirection);
+                    DrawController.ViewSelectedPoints(pointsDirection);
+
+                    if (points.Length <= 1 && (DrawController.pointOffsetMin == DrawController.pointOffsetMax))
+                    {
+                        ViewSingleSelectorAtCurrentPosition(_stateImageSideType, false);
+                        break;
+                    }
+
                     Point point1 = DrawController.pointOffsetMin;
                     point1.X += DrawController.pointOffset.X;
                     point1.Y += DrawController.pointOffset.Y;
@@ -364,8 +365,6 @@ namespace AdaptiveSpritesDMItool.Controllers
                     point2.X += DrawController.pointOffset.X;
                     point2.Y += DrawController.pointOffset.Y;
 
-                    var pointsDirection = DrawController.GetStoragePoints(StatesController.currentStateDirection);
-                    DrawController.ViewSelectedPoints(pointsDirection);
                     ViewMultSelectorAtPoints(_stateImageSideType, point1, point2, false);
                     break;
             }

--- a/Controllers/EnvironmentController.cs
+++ b/Controllers/EnvironmentController.cs
@@ -72,17 +72,6 @@ namespace AdaptiveSpritesDMItool.Controllers
             int height = dataImageState.imageCellsSize.Height;
 
             dataPixelStorage = new DataPixelStorage(GetPixelStoragePath(), width, height);
-
-            //dataPixelStorage = new DataPixelStorage((width, height)[] points);
-
-            //cellsData = new Point[width, height];
-            //for (int i = 0; i < width; i++)
-            //{
-            //    for (int j = 0; j < height; j++)
-            //    {
-            //        cellsData[i, j] = new Point(i, j);
-            //    }
-            //}
         }
 
         #endregion Loaders

--- a/Controllers/MouseController.cs
+++ b/Controllers/MouseController.cs
@@ -158,7 +158,17 @@ namespace AdaptiveSpritesDMItool.Controllers
 
         #region Getters
 
-        public static Point GetCurrentMousePosition() => currentMousePosition;
+        public static bool isMouseInPoints(Point[] _points)
+        {
+            if (_points == null || _points.Length == 0)
+                return false;
+
+            var x = currentMousePosition.X;
+            var y = currentMousePosition.Y;
+
+            return _points.Any(p => p.X == x && p.Y == y);
+        }
+
 
         #endregion Getters
     }

--- a/Controllers/MouseController.cs
+++ b/Controllers/MouseController.cs
@@ -38,7 +38,7 @@ namespace AdaptiveSpritesDMItool.Controllers
                     EditorController.EditFillModeStart(_stateImageSideType);
                     break;
                 case StateEditType.Move:
-                    EditorController.EditMoveMode(_stateImageSideType);
+                    EditorController.EditMoveModeStart(_stateImageSideType);
                     break;
                 case StateEditType.Select:
                     EditorController.EditSelectModeStart(_stateImageSideType);
@@ -66,6 +66,9 @@ namespace AdaptiveSpritesDMItool.Controllers
             {
                 case StateEditType.Fill:
                     EditorController.EditFillModeEnd(_stateImageSideType);
+                    break;
+                case StateEditType.Move:
+                    EditorController.EditMoveModeEnd(_stateImageSideType);
                     break;
                 case StateEditType.Select:
                     EditorController.EditSelectModeEnd(_stateImageSideType);

--- a/Models/StateEditType.cs
+++ b/Models/StateEditType.cs
@@ -13,8 +13,8 @@ namespace AdaptiveSpritesDMItool.Models
     {
         Single,
         Fill,
-        Select,
         Move,
+        Select,
         Delete,
         Undo,
         UndoArea
@@ -47,5 +47,12 @@ namespace AdaptiveSpritesDMItool.Models
     {
         Left,
         Right
+    }
+
+    public enum SelectMode
+    {
+        None,
+        Select,
+        Move
     }
 }

--- a/Resources/DataPixelStorage.cs
+++ b/Resources/DataPixelStorage.cs
@@ -10,6 +10,8 @@ using System.Threading.Tasks;
 using System.Windows.Media.Imaging;
 using System.Windows.Media;
 using System.Windows.Media.Media3D;
+using Point = System.Drawing.Point;
+using Color = System.Windows.Media.Color;
 
 namespace AdaptiveSpritesDMItool.Resources
 {
@@ -49,6 +51,29 @@ namespace AdaptiveSpritesDMItool.Resources
                 );
             }
 
+        }
+
+
+
+        public Point GetPointStorage(StateDirection direction, Point point)
+        {
+            var storagePoint = ConvertToStoragePoint(point);
+            return ConvertFromStoragePoint(pixelStorages[direction][storagePoint]);
+        }
+
+        public (int x, int y) GetPointStorage(StateDirection direction, (int x, int y) point)
+        {
+            return pixelStorages[direction][point];
+        }
+
+        private Point ConvertFromStoragePoint((int x, int y) point)
+        {
+            return new Point(point.x, point.y);
+        }
+
+        private (int x, int y) ConvertToStoragePoint(Point point)
+        {
+            return (point.X, point.Y);
         }
 
         #endregion Edit

--- a/Views/Windows/MainWindow.xaml
+++ b/Views/Windows/MainWindow.xaml
@@ -30,7 +30,6 @@
             x:Name="RootNavigation"
             Grid.Row="1"
             Padding="42,0,42,0"
-            BreadcrumbBar="{Binding ElementName=BreadcrumbBar}"
             FooterMenuItemsSource="{Binding ViewModel.FooterMenuItems, Mode=OneWay}"
             FrameMargin="0"
             IsBackButtonVisible="Visible"
@@ -38,6 +37,7 @@
             MenuItemsSource="{Binding ViewModel.MenuItems, Mode=OneWay}"
             PaneDisplayMode="LeftFluent">
             <!--Commented out to not show the top selected one-->
+            <!--BreadcrumbBar="{Binding ElementName=BreadcrumbBar}">-->
             <!--<ui:NavigationView.Header>
                 <ui:BreadcrumbBar x:Name="BreadcrumbBar" Margin="42,32,42,20" />
             </ui:NavigationView.Header>-->


### PR DESCRIPTION
Добавляем 2 инструмента для смещения пикселей или целых зон пикселей.
Не самая лучшая реализация, хотел через запоминания массива пикселей измененных чтобы не приходилось отрисовывать всё каждый раз, но WritebleBitmaps такого не предполагает, или это делается через мутные схемы.
Поэтому будет текущая не самая эффективная и экономная реализация. В потенциальном будущем надо будет всё перенести на Image которые мы будем обрабатывать и уже только потом конвертировать их в Битмапы загружая на полотна.
Ну... TODO когда-нибудь.
![image](https://github.com/user-attachments/assets/1551ff09-2ae5-4f1d-ad62-72e916f3bac7)


Видео:
https://discord.com/channels/1097181193939730453/1097521716013568011/1278416588734988361
